### PR TITLE
refactor example.h to reproduce static inline issue

### DIFF
--- a/src/example.h
+++ b/src/example.h
@@ -1,169 +1,198 @@
-#ifndef _EXAMPLE_H
-#define _EXAMPLE_H
+#ifndef EXAMPLE_H_
+#define EXAMPLE_H_
+
+#ifndef UNITTEST
+
+static __inline__ __attribute__ ((always_inline)) uint16_t inline_func_0 (uint32_t a);
+static __inline__ __attribute__ ((always_inline)) uint16_t inline_func_1 (uint32_t a);
+static __inline__ __attribute__ ((always_inline)) uint16_t inline_func_2 (uint32_t a);
+static __inline__ __attribute__ ((always_inline)) uint16_t inline_func_3 (uint32_t a);
+static __inline__ __attribute__ ((always_inline)) uint16_t inline_func_4 (uint32_t a);
+static __inline__ __attribute__ ((always_inline)) uint16_t inline_func_5 (uint32_t a);
+static __inline__ __attribute__ ((always_inline)) uint16_t inline_func_6 (uint32_t a);
+static __inline__ __attribute__ ((always_inline)) uint16_t inline_func_7 (uint32_t a);
+static __inline__ __attribute__ ((always_inline)) uint16_t inline_func_8 (uint32_t a);
+static __inline__ __attribute__ ((always_inline)) uint16_t inline_func_9 (uint32_t a);
+static __inline__ __attribute__ ((always_inline)) uint16_t inline_func_10 (uint32_t a);
+static __inline__ __attribute__ ((always_inline)) uint16_t inline_func_11 (uint32_t a);
+static __inline__ __attribute__ ((always_inline)) uint16_t inline_func_12 (uint32_t a);
+static __inline__ __attribute__ ((always_inline)) uint16_t inline_func_13 (uint32_t a);
+static __inline__ __attribute__ ((always_inline)) uint16_t inline_func_14 (uint32_t a);
+static __inline__ __attribute__ ((always_inline)) uint16_t inline_func_15 (uint32_t a);
+static __inline__ __attribute__ ((always_inline)) uint16_t inline_func_16 (uint32_t a);
+
+#endif
+
+
+static __inline__ uint16_t inline_func_0 (uint32_t a)
+{
+    return (uint16_t) a;
+}
+
+static __inline__ uint16_t inline_func_1 (uint32_t a)
+{
+    return (uint16_t) (a);
+}
+
+static __inline__ uint16_t inline_func_2 (uint32_t a)
+{
+    return (uint16_t) (a);
+}
+
+static __inline__ uint16_t inline_func_3 (uint32_t a)
+{
+    return (uint16_t) (a);
+}
+
+static __inline__ uint16_t inline_func_4 (uint32_t a)
+{
+    return (uint16_t) (a);
+}
+
+static __inline__ uint16_t inline_func_8 (uint32_t a)
+{
+    return (uint16_t) (a);
+}
+
+static __inline__ uint16_t inline_func_5 (uint32_t a)
+{
+    return (uint16_t) (a);
+}
+
+static __inline__ uint16_t inline_func_6 (uint32_t a)
+{
+    return (uint16_t) (a);
+}
+
+static __inline__ uint16_t inline_func_7 (uint32_t a)
+{
+    return (uint16_t) (a);
+}
+
+static __inline__ uint16_t inline_func_9 (uint32_t a)
+{
+    return (uint16_t) (a);
+}
+
+static __inline__ uint16_t inline_func_10 (uint32_t a)
+{
+    return (uint16_t) (a);
+}
+
+static __inline__ uint16_t inline_func_12 (uint32_t a)
+{
+    return (uint16_t) (a);
+}
+
+static __inline__ uint16_t inline_func_11 (uint32_t a)
+{
+    return (uint16_t) (a);
+}
+
+static __inline__ uint16_t inline_func_16 (uint32_t a)
+{
+    return (uint16_t) (a);
+}
+
+static __inline__ uint16_t inline_func_13 (uint32_t a)
+{
+    return (uint16_t) (a);
+}
+
+static __inline__ uint16_t inline_func_14 (uint32_t a)
+{
+    return (uint16_t) (a);
+}
+
+static __inline__ uint16_t inline_func_15 (uint32_t a)
+{
+    return (uint16_t) (a);
+}
 
 static __inline__ __attribute__ ((always_inline)) uint16_t alwaysinline_func_0 (uint32_t a)
 {
-	return (uint16_t)a;
+    return inline_func_16(a);
 }
 
 static __inline__ __attribute__ ((always_inline)) uint16_t alwaysinline_func_1 (uint32_t a)
 {
-	return (uint16_t)a;
+    return inline_func_15(a);
 }
 
 static __inline__ __attribute__ ((always_inline)) uint16_t alwaysinline_func_2 (uint32_t a)
 {
-	return (uint16_t)a;
+    return inline_func_14(a);
 }
 
 static __inline__ __attribute__ ((always_inline)) uint16_t alwaysinline_func_3 (uint32_t a)
 {
-	return (uint16_t)a;
+    return inline_func_13(a);
 }
 
 static __inline__ __attribute__ ((always_inline)) uint16_t alwaysinline_func_4 (uint32_t a)
 {
-	return (uint16_t)a;
+    return inline_func_12(a);
 }
 
 static __inline__ __attribute__ ((always_inline)) uint16_t alwaysinline_func_5 (uint32_t a)
 {
-	return (uint16_t)a;
+    return inline_func_11(a);
 }
 
 static __inline__ __attribute__ ((always_inline)) uint16_t alwaysinline_func_6 (uint32_t a)
 {
-	return (uint16_t)a;
+    return inline_func_10(a);
 }
 
 static __inline__ __attribute__ ((always_inline)) uint16_t alwaysinline_func_7 (uint32_t a)
 {
-	return (uint16_t)a;
+    return inline_func_9 (a);
 }
 
 static __inline__ __attribute__ ((always_inline)) uint16_t alwaysinline_func_8 (uint32_t a)
 {
-	return (uint16_t)a;
+    return inline_func_8 (a);
 }
 
 static __inline__ __attribute__ ((always_inline)) uint16_t alwaysinline_func_9 (uint32_t a)
 {
-	return (uint16_t)a;
+    return inline_func_7 (a);
 }
 
 static __inline__ __attribute__ ((always_inline)) uint16_t alwaysinline_func_10 (uint32_t a)
 {
-	return (uint16_t)a;
+    return inline_func_6 (a);
 }
 
 static __inline__ __attribute__ ((always_inline)) uint16_t alwaysinline_func_11 (uint32_t a)
 {
-	return (uint16_t)a;
+    return inline_func_5 (a);
 }
 
 static __inline__ __attribute__ ((always_inline)) uint16_t alwaysinline_func_12 (uint32_t a)
 {
-	return (uint16_t)a;
+    return inline_func_4 (a);
 }
 
 static __inline__ __attribute__ ((always_inline)) uint16_t alwaysinline_func_13 (uint32_t a)
 {
-	return (uint16_t)a;
+    return inline_func_3 (a);
 }
 
 static __inline__ __attribute__ ((always_inline)) uint16_t alwaysinline_func_14 (uint32_t a)
 {
-	return (uint16_t)a;
+    return inline_func_2 (a);
 }
 
 static __inline__ __attribute__ ((always_inline)) uint16_t alwaysinline_func_15 (uint32_t a)
 {
-	return (uint16_t)a;
+    return inline_func_1 (a);
 }
 
-static __inline__ uint16_t inline_func_0  (uint32_t a)
+static __inline__ __attribute__ ((always_inline)) uint16_t alwaysinline_func_16 (uint32_t a)
 {
-    return (uint16_t) a;
+    return inline_func_0 (a);
 }
 
-static __inline__ uint16_t inline_func_1  (uint32_t a)
-{
-    return (uint16_t) a;
-}
+#endif /* EXAMPLE_H_ */
 
-static __inline__ uint16_t inline_func_2  (uint32_t a)
-{
-    return (uint16_t) a;
-}
-
-static __inline__ uint16_t inline_func_3  (uint32_t a)
-{
-    return (uint16_t) a;
-}
-
-static __inline__ uint16_t inline_func_4  (uint32_t a)
-{
-    return (uint16_t) a;
-}
-
-static __inline__ uint16_t inline_func_5  (uint32_t a)
-{
-    return (uint16_t) a;
-}
-
-static __inline__ uint16_t inline_func_6  (uint32_t a)
-{
-    return (uint16_t) a;
-}
-
-static __inline__ uint16_t inline_func_7  (uint32_t a)
-{
-    return (uint16_t) a;
-}
-
-static __inline__ uint16_t inline_func_8  (uint32_t a)
-{
-    return (uint16_t) a;
-}
-
-static __inline__ uint16_t inline_func_9  (uint32_t a)
-{
-    return (uint16_t) a;
-}
-
-static __inline__ uint16_t inline_func_10  (uint32_t a)
-{
-    return (uint16_t) a;
-}
-
-static __inline__ uint16_t inline_func_11  (uint32_t a)
-{
-    return (uint16_t) a;
-}
-
-static __inline__ uint16_t inline_func_12  (uint32_t a)
-{
-    return (uint16_t) a;
-}
-
-static __inline__ uint16_t inline_func_13  (uint32_t a)
-{
-    return (uint16_t) a;
-}
-
-static __inline__ uint16_t inline_func_14  (uint32_t a)
-{
-    return (uint16_t) a;
-}
-
-static __inline__ uint16_t inline_func_15  (uint32_t a)
-{
-    return (uint16_t) a;
-}
-
-static __inline__ uint16_t inline_func_16  (uint32_t a)
-{
-    return (uint16_t) a;
-}
-
-#endif /* _EXAMPLE_H */


### PR DESCRIPTION
This example.h triggers the issue where the mocked inline_func still contains the `static __inline__` which is expected to be stripped...

fun fact: removing lines 4-25 (declarations) seems to resolve the issue.